### PR TITLE
Change version string for TYPO3 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "",
   "license": "GPL-2.0+",
   "require": {
-    "typo3/cms": "8.7.10",
+    "typo3/cms": "^8.7.10",
     "cweagans/composer-patches": "~1.0"
   },
   "autoload": {


### PR DESCRIPTION
Change TYPO3 version to be usable for 8.7.10 and higher.