### PR TITLE
Require typo3/cms-core instead of typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "",
   "license": "GPL-2.0+",
   "require": {
-    "typo3/cms": "^8.7.10",
+    "typo3/cms-core": "^8.7.10",
     "cweagans/composer-patches": "~1.0"
   },
   "autoload": {


### PR DESCRIPTION
In TYPO3 extension you shouldn't require `typo3/cms`.
See: https://insight.helhum.io/post/148886148725/composerjson-specification-for-typo3-extensions